### PR TITLE
🐛 Fixes on `edit_distance`, `offset_in_gfa` and main calls

### DIFF
--- a/pancat/main.py
+++ b/pancat/main.py
@@ -143,7 +143,7 @@ parser_edit.add_argument(
 parser_edit.add_argument(
     "-o", "--output_path", required=True, type=str, help="Path to a .json output for results.")
 parser_edit.add_argument(
-    "-g", "--graph_level", help="Asks to perform edition computation at graph level.", action='store_true')
+    "-g", "--graph_level", help="Asks to perform edition computation at graph level.", action='store_true', default=False)
 parser_edit.add_argument(
     "--selection", type=str, help="Name(s) for the paths you want to reconstruct.", nargs='*', default=True)
 
@@ -259,7 +259,8 @@ def main() -> None:
             gfa_A=args.graph_A,
             gfa_B=args.graph_B,
             output_path=args.output_path,
-            selection=not args.graph_level or args.selection
+            graph_level=args.graph_level,
+            selection=args.selection
         )
 
     ##############################################################################

--- a/pancat/offset_in_gfa.py
+++ b/pancat/offset_in_gfa.py
@@ -20,5 +20,6 @@ def add_offsets_to_gfa(gfa_file: str, output_file: str) -> None:
         output_file (str): output gfa file
         gfa_version (str): the user-assumed gfa subformat
     """
-    gfa_graph: Graph = Graph(gfa_file, with_sequence=True).sequence_offsets()
+    gfa_graph: Graph = Graph(gfa_file, with_sequence=True)
+    gfa_graph.sequence_offsets()
     gfa_graph.save_graph(output_file=output_file)


### PR DESCRIPTION
This merge validates graph-level edition as stable and usable. It can be called with command-line, and outputs editions at graph-level (meaning same editions won't be accounted multiple times)